### PR TITLE
rename IPriceFeed to IPerpdexPriceFeed

### DIFF
--- a/contracts/BandPriceFeed.sol
+++ b/contracts/BandPriceFeed.sol
@@ -3,10 +3,10 @@ pragma solidity 0.7.6;
 pragma experimental ABIEncoderV2;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
-import { IPriceFeed } from "./interface/IPriceFeed.sol";
+import { IPerpdexPriceFeed } from "./interface/IPerpdexPriceFeed.sol";
 import { IStdReference } from "./interface/bandProtocol/IStdReference.sol";
 
-contract BandPriceFeed is IPriceFeed {
+contract BandPriceFeed is IPerpdexPriceFeed {
     using Address for address;
 
     //

--- a/contracts/ChainlinkPriceFeed.sol
+++ b/contracts/ChainlinkPriceFeed.sol
@@ -3,9 +3,9 @@ pragma solidity 0.7.6;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol";
-import { IPriceFeed } from "./interface/IPriceFeed.sol";
+import { IPerpdexPriceFeed } from "./interface/IPerpdexPriceFeed.sol";
 
-contract ChainlinkPriceFeed is IPriceFeed {
+contract ChainlinkPriceFeed is IPerpdexPriceFeed {
     using Address for address;
 
     AggregatorV3Interface private immutable _aggregator;

--- a/contracts/DiaPriceFeed.sol
+++ b/contracts/DiaPriceFeed.sol
@@ -3,10 +3,10 @@ pragma solidity 0.7.6;
 pragma experimental ABIEncoderV2;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
-import { IPriceFeed } from "./interface/IPriceFeed.sol";
+import { IPerpdexPriceFeed } from "./interface/IPerpdexPriceFeed.sol";
 import { IDIAOracleV2 } from "./interface/dia/IDIAOracleV2.sol";
 
-contract DiaPriceFeed is IPriceFeed {
+contract DiaPriceFeed is IPerpdexPriceFeed {
     using Address for address;
 
     //

--- a/contracts/UniswapV3PriceFeed.sol
+++ b/contracts/UniswapV3PriceFeed.sol
@@ -6,9 +6,9 @@ import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import { FixedPoint96 } from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
 import { FullMath } from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
-import { IPriceFeed } from "./interface/IPriceFeed.sol";
+import { IPerpdexPriceFeed } from "./interface/IPerpdexPriceFeed.sol";
 
-contract UniswapV3PriceFeed is IPriceFeed {
+contract UniswapV3PriceFeed is IPerpdexPriceFeed {
     using Address for address;
 
     //

--- a/contracts/interface/IPerpdexPriceFeed.sol
+++ b/contracts/interface/IPerpdexPriceFeed.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.7.6;
 
-interface IPriceFeed {
+interface IPerpdexPriceFeed {
     function decimals() external view returns (uint8);
 
     /// @dev Returns the index price of the token.

--- a/contracts/test/TestPriceFeed.sol
+++ b/contracts/test/TestPriceFeed.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.7.6;
 
-import { IPriceFeed } from "../interface/IPriceFeed.sol";
+import { IPerpdexPriceFeed } from "../interface/IPerpdexPriceFeed.sol";
 
 contract TestPriceFeed {
     address public chainlink;
@@ -19,10 +19,10 @@ contract TestPriceFeed {
     // for gas usage testing
     //
     function fetchChainlinkPrice() external {
-        currentPrice = IPriceFeed(chainlink).getPrice();
+        currentPrice = IPerpdexPriceFeed(chainlink).getPrice();
     }
 
     function fetchBandProtocolPrice() external {
-        currentPrice = IPriceFeed(bandProtocol).getPrice();
+        currentPrice = IPerpdexPriceFeed(bandProtocol).getPrice();
     }
 }


### PR DESCRIPTION
Add Perpdex prefix to interface because interface names are difficult for others to handle unless they are globally unique.